### PR TITLE
Improve load speed

### DIFF
--- a/data.json
+++ b/data.json
@@ -13,5 +13,8 @@
         "logs.flake.sh",
         "logs.potat.app"
     ],
+    "alternateEndpoint":{
+        "logs.lucas19961.de": "logsback.susgee.dev"
+    },
     "recentmessagesInstances": ["recent-messages.zneix.eu", "recent-messages.robotty.de"]
 }

--- a/data.json
+++ b/data.json
@@ -10,7 +10,8 @@
         "logs.magichack.xyz",
         "logs.lucas19961.de",
         "logs.jimmyboy.dev",
-        "logs.flake.sh"
+        "logs.flake.sh",
+        "logs.potat.app"
     ],
     "recentmessagesInstances": ["recent-messages.zneix.eu", "recent-messages.robotty.de"]
 }

--- a/data.json
+++ b/data.json
@@ -14,7 +14,8 @@
         "logs.potat.app"
     ],
     "alternateEndpoint":{
-        "logs.lucas19961.de": "logsback.susgee.dev"
+        "logs.lucas19961.de": "logsback.susgee.dev",
+        "harambelogs.pl": "logs.zneix.eu"
     },
     "recentmessagesInstances": ["recent-messages.zneix.eu", "recent-messages.robotty.de"]
 }

--- a/index.js
+++ b/index.js
@@ -29,43 +29,37 @@ app.get('/contact', async (req, res) => {
 });
 
 app.get('/rdr/:channel', async (req, res) => {
-    const channel = utils.formatUsername(decodeURIComponent(req.params.channel));
+    const channel = utils.formatUsername(req.params.channel);
 
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(channel))
+    if (!utils.userChanRegex.test(channel))
         return res.render('error', { error: `Invalid channel or channel ID: ${channel}`, code: '' });
 
     const { pretty } = req.query;
 
     try {
         const instance = await utils.getInstance(channel, null, 'true', pretty);
-        if (instance.error) {
-            return res.render('error', { error: instance.error, code: '' });
-        } else {
-            return res.redirect(instance?.channelLogs?.fullLink[0]);
-        }
+        if (instance.error) return res.render('error', { error: instance.error, code: '' });
+        else return res.redirect(instance?.channelLogs?.fullLink[0]);
     } catch (err) {
         return res.render('error', { error: `Internal error${err.message ? ` - ${err.message}` : ''}`, code: '' });
     }
 });
 
 app.get('/rdr/:channel/:user', async (req, res) => {
-    const channel = utils.formatUsername(decodeURIComponent(req.params.channel));
-    const user = utils.formatUsername(decodeURIComponent(req.params.user));
+    const channel = utils.formatUsername(req.params.channel);
+    const user = utils.formatUsername(req.params.user);
 
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(channel))
+    if (!utils.userChanRegex.test(channel))
         return res.render('error', { error: `Invalid channel or channel ID: ${channel}`, code: '' });
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(user))
+    if (!utils.userChanRegex.test(user))
         return res.render('error', { error: `Invalid username or user ID: ${user}`, code: '' });
 
     const { pretty } = req.query;
 
     try {
         const instance = await utils.getInstance(channel, user, 'true', pretty);
-        if (instance.error) {
-            return res.render('error', { error: instance.error, code: '' });
-        } else {
-            return res.redirect(instance?.userLogs?.fullLink[0]);
-        }
+        if (instance.error) return res.render('error', { error: instance.error, code: '' });
+        else return res.redirect(instance?.userLogs?.fullLink[0]);
     } catch (err) {
         return res.render('error', { error: `Internal error${err.message ? ` - ${err.message}` : ''}`, code: '' });
     }
@@ -73,56 +67,46 @@ app.get('/rdr/:channel/:user', async (req, res) => {
 
 app.get('/api/:channel', async (req, res) => {
     const { force, full, pretty, plain } = req.query;
-    const channel = utils.formatUsername(decodeURIComponent(req.params.channel));
+    const channel = utils.formatUsername(req.params.channel);
     let error = null;
 
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(channel))
+    if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;
 
+    const isPlain = plain?.toLowerCase() === 'true';
     try {
         const instances = await utils.getInstance(channel, null, force, pretty, full, error);
-        if (plain?.toLowerCase() === 'true') {
-            return res.send(instances?.channelLogs?.fullLink[0] ?? instances?.error);
-        } else {
-            return res.send(instances);
-        }
+        if (isPlain) return res.send(instances?.channelLogs?.fullLink[0] ?? instances?.error);
+        else return res.send(instances);
     } catch (err) {
-        if (plain?.toLowerCase() === 'true') {
-            return res.send(`Internal error${err.message ? ` - ${err.message}` : ''}`);
-        } else {
-            return res.send({ error: `Internal error${err.message ? ` - ${err.message}` : ''}` });
-        }
+        if (isPlain) return res.send(`Internal error${err.message ? ` - ${err.message}` : ''}`);
+        else return res.send({ error: `Internal error${err.message ? ` - ${err.message}` : ''}` });
     }
 });
 
 app.get('/api/:channel/:user', async (req, res) => {
     const { force, full, pretty, plain } = req.query;
-    const channel = utils.formatUsername(decodeURIComponent(req.params.channel));
-    const user = utils.formatUsername(decodeURIComponent(req.params.user));
+    const channel = utils.formatUsername(req.params.channel);
+    const user = utils.formatUsername(req.params.user);
     let error = null;
 
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(channel))
+    if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;
-    if (!new RegExp(/^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i).exec(user)) error = `Invalid username or user ID: ${user}`;
+    if (!utils.userChanRegex.test(user)) error = `Invalid username or user ID: ${user}`;
 
+    const isPlain = plain?.toLowerCase() === 'true';
     try {
         const instances = await utils.getInstance(channel, user, force, pretty, full, error);
-        if (plain?.toLowerCase() === 'true') {
-            return res.send(instances?.userLogs?.fullLink[0] ?? instances?.error);
-        } else {
-            return res.send(instances);
-        }
+        if (isPlain) return res.send(instances?.userLogs?.fullLink[0] ?? instances?.error);
+        else return res.send(instances);
     } catch (err) {
-        if (plain?.toLowerCase() === 'true') {
-            return res.send(`Internal error${err.message ? ` - ${err.message}` : ''}`);
-        } else {
-            return res.send({ error: `Internal error${err.message ? ` - ${err.message}` : ''}` });
-        }
+        if (isPlain) return res.send(`Internal error${err.message ? ` - ${err.message}` : ''}`);
+        else return res.send({ error: `Internal error${err.message ? ` - ${err.message}` : ''}` });
     }
 });
 
 app.get('/rm/:channel', async (req, res) => {
-    const channel = utils.formatUsername(decodeURIComponent(req.params.channel));
+    const channel = utils.formatUsername(req.params.channel);
 
     try {
         const recentMessages = await utils.getRecentMessages(channel, req.query);

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ app.get('/rdr/:channel/:user', async (req, res) => {
 });
 
 app.get('/api/:channel', async (req, res) => {
-    const { force, full, pretty, plain } = req.query;
+    const { force, pretty, plain } = req.query;
     const channel = utils.formatUsername(req.params.channel);
     let error = null;
 
@@ -77,7 +77,7 @@ app.get('/api/:channel', async (req, res) => {
 
     const isPlain = plain?.toLowerCase() === 'true';
     try {
-        const instances = await utils.getInstance(channel, null, force, pretty, full, error);
+        const instances = await utils.getInstance(channel, null, force, pretty, error);
         if (isPlain) return res.send(instances?.channelLogs?.fullLink[0] ?? instances?.error);
         else return res.send(instances);
     } catch (err) {
@@ -87,7 +87,7 @@ app.get('/api/:channel', async (req, res) => {
 });
 
 app.get('/api/:channel/:user', async (req, res) => {
-    const { force, full, pretty, plain } = req.query;
+    const { force, pretty, plain } = req.query;
     const channel = utils.formatUsername(req.params.channel);
     const user = utils.formatUsername(req.params.user);
     let error = null;
@@ -100,7 +100,7 @@ app.get('/api/:channel/:user', async (req, res) => {
 
     const isPlain = plain?.toLowerCase() === 'true';
     try {
-        const instances = await utils.getInstance(channel, user, force, pretty, full, error);
+        const instances = await utils.getInstance(channel, user, force, pretty, error);
         if (isPlain) return res.send(instances?.userLogs?.fullLink[0] ?? instances?.error);
         else return res.send(instances);
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const data = require('./data.json');
 const express = require('express');
 const utils = require('./utils');
 const app = express();
-const port = 2028;
+const port = 3111;
 
 app.use('/favicon.ico', express.static(`${__dirname}/static/favicon.ico`));
 app.use('/static', express.static(`${__dirname}/static`));
@@ -132,5 +132,6 @@ app.use(function (err, req, res, next) {
 });
 
 app.listen(port, () => {
+    utils.loopLoadInstanceChannels();
     console.log(`Logs website listening on ${port}`);
 });

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ app.get('/api/:channel', async (req, res) => {
     const channel = utils.formatUsername(req.params.channel);
     let error = null;
 
-    if (force) utils.loopLoadInstanceChannels();
+    if (force) await utils.loopLoadInstanceChannels();
 
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;
@@ -92,7 +92,7 @@ app.get('/api/:channel/:user', async (req, res) => {
     const user = utils.formatUsername(req.params.user);
     let error = null;
 
-    if (force) utils.loopLoadInstanceChannels();
+    if (force) await utils.loopLoadInstanceChannels();
 
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;

--- a/index.js
+++ b/index.js
@@ -70,8 +70,6 @@ app.get('/api/:channel', async (req, res) => {
     const channel = utils.formatUsername(req.params.channel);
     let error = null;
 
-    if (force) await utils.loopLoadInstanceChannels();
-
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;
 
@@ -91,8 +89,6 @@ app.get('/api/:channel/:user', async (req, res) => {
     const channel = utils.formatUsername(req.params.channel);
     const user = utils.formatUsername(req.params.user);
     let error = null;
-
-    if (force) await utils.loopLoadInstanceChannels();
 
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const data = require('./data.json');
 const express = require('express');
 const utils = require('./utils');
 const app = express();
-const port = 3111;
+const port = 2028;
 
 app.use('/favicon.ico', express.static(`${__dirname}/static/favicon.ico`));
 app.use('/static', express.static(`${__dirname}/static`));

--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ app.get('/api/:channel', async (req, res) => {
     const channel = utils.formatUsername(req.params.channel);
     let error = null;
 
+    if (force) utils.loopLoadInstanceChannels();
+
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;
 
@@ -89,6 +91,8 @@ app.get('/api/:channel/:user', async (req, res) => {
     const channel = utils.formatUsername(req.params.channel);
     const user = utils.formatUsername(req.params.user);
     let error = null;
+
+    if (force) utils.loopLoadInstanceChannels();
 
     if (!utils.userChanRegex.test(channel))
         error = `Invalid channel or channel ID: ${channel}`;

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "dependencies": {
         "ejs": "^3.1.9",
         "express": "^4.18.2",
-        "got": "^11.8.6",
-        "ioredis": "^5.3.2"
+        "got": "^11.8.6"
     },
     "scripts": {
         "start": "node index.js"

--- a/utils.js
+++ b/utils.js
@@ -27,10 +27,8 @@ module.exports = new class LogUtils {
         let count = new Set();
         await Promise.allSettled(data.justlogsInstances.map(async (url) => {
             try {
-                let thisURL;
-                if (url === 'logs.lucas19961.de') thisURL = 'logsback.susgee.dev'
-                else thisURL = url;
-                const logsData = await got(`https://${thisURL}/channels`, {
+                if (data.alternateEndpoint[url]) url = data.alternateEndpoint[url]
+                const logsData = await got(`https://${url}/channels`, {
                     headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
                     responseType: 'json',
                     timeout: 5000,

--- a/utils.js
+++ b/utils.js
@@ -139,7 +139,7 @@ module.exports = new class LogUtils {
                 fullLink: channelLinks,
             },
             lastUpdated: {
-                unix: Number(this.lastUpdated / 1000),
+                unix: ~~(this.lastUpdated / 1000),
                 utc: new Date(this.lastUpdated * 1000).toUTCString(),
             },
             elapsed: {

--- a/utils.js
+++ b/utils.js
@@ -139,7 +139,7 @@ module.exports = new class LogUtils {
                 fullLink: channelLinks,
             },
             lastUpdated: {
-                unix: Number(this.lastUpdated),
+                unix: Number(this.lastUpdated / 1000),
                 utc: new Date(this.lastUpdated * 1000).toUTCString(),
             },
             elapsed: {
@@ -153,7 +153,7 @@ module.exports = new class LogUtils {
         const channels = this.instanceChannels.get(url) ?? [];
         const channelPath = channel.match(this.userIdRegex) ? 'channelid' : 'channel';
         const channelClean = channel.replace('id:', '');
-        console.log(url, channels.length)
+
         if (!channels.length) return { Status: 0 };
         if (!channels.includes(channelClean)) return { Status: 3 };
 

--- a/utils.js
+++ b/utils.js
@@ -67,9 +67,8 @@ module.exports = new class LogUtils {
         );
     }
 
-    async getInstance(channel, user, force, pretty, full, error) {
+    async getInstance(channel, user, force, pretty, error) {
         force = force?.toLowerCase() === 'true';
-        full = full?.toLowerCase() === 'true';
         const instances = data.justlogsInstances;
     
         let downSites = 0;
@@ -92,14 +91,13 @@ module.exports = new class LogUtils {
                 switch (Status) {
                     case 0:
                         downSites++;
-                        break;
+                        continue;
                     case 1:
                         channelLinks.push(channelFull);
                         channelInstances.push(Link);
                         userInstances.push(Link);
                         userLinks.push(Full);
-                        if (full) continue;
-                        break;
+                        continue;
                     case 2:
                         channelLinks.push(channelFull);
                         channelInstances.push(Link);
@@ -107,7 +105,6 @@ module.exports = new class LogUtils {
                     case 3:
                         continue;
                 }
-                break;
             }
         }
         
@@ -196,8 +193,9 @@ module.exports = new class LogUtils {
             `https://${url}/?channel=${channel}` :
             `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
 
+        console.log(`[${url}] Channel: ${channel} - User: ${user} - ${statusCode}`)
         return {
-            Status: ~~(statusCode/100) === 2 ? 2 : 1,
+            Status: ~~(statusCode/100) === 2 ? 1 : 2,
             Link: `https://${url}`,
             Full: fullLink,
             channelFull: channelFull,

--- a/utils.js
+++ b/utils.js
@@ -158,8 +158,6 @@ module.exports = new class LogUtils {
     };
 
     async getLogs(url, user, channel, force, pretty) {
-        if (force) await this.loopLoadInstanceChannels();
-    
         const channels = this.instanceChannels.get(url) ?? [];
         const channelPath = channel.match(this.userIdRegex) ? 'channelid' : 'channel';
         const channelClean = channel.replace('id:', '');

--- a/utils.js
+++ b/utils.js
@@ -28,8 +28,8 @@ module.exports = new class LogUtils {
         let count = new Set();
         await Promise.allSettled(data.justlogsInstances.map(async (url) => {
             try {
-                if (data.alternateEndpoint[url]) url = data.alternateEndpoint[url]
-                const logsData = await got(`https://${url}/channels`, {
+                const channelURL = data.alternateEndpoint[url] ?? url;
+                const logsData = await got(`https://${channelURL}/channels`, {
                     headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
                     https: {
                         rejectUnauthorized: false
@@ -53,6 +53,7 @@ module.exports = new class LogUtils {
                 this.instanceChannels.set(url, [])
             }
         }))
+        this.statusCodes.clear();
         this.lastUpdated = Date.now();
         console.log(`Loaded ${count.size} channels from ${data.justlogsInstances.length} instances`);
     }
@@ -152,7 +153,7 @@ module.exports = new class LogUtils {
         const channels = this.instanceChannels.get(url) ?? [];
         const channelPath = channel.match(this.userIdRegex) ? 'channelid' : 'channel';
         const channelClean = channel.replace('id:', '');
-
+        console.log(url, channels.length)
         if (!channels.length) return { Status: 0 };
         if (!channels.includes(channelClean)) return { Status: 3 };
 

--- a/utils.js
+++ b/utils.js
@@ -30,6 +30,9 @@ module.exports = new class LogUtils {
                 if (data.alternateEndpoint[url]) url = data.alternateEndpoint[url]
                 const logsData = await got(`https://${url}/channels`, {
                     headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
+                    https: {
+                        rejectUnauthorized: false
+                    },
                     responseType: 'json',
                     timeout: 5000,
                     http2: true,

--- a/utils.js
+++ b/utils.js
@@ -1,256 +1,257 @@
 const data = require('./data.json');
 const ioredis = require('ioredis');
 const got = require('got');
-const utils = this;
 
-exports.formatUsername = (username) => {
-    return username.replace('@', '').replace(',', '').replace('#', '').toLowerCase();
-};
+module.exports = new class LogUtils {
+    redis = new ioredis();
 
-exports.redis = new ioredis();
+    userIdRegex = /^id:(\d{1,})$/i;
 
-exports.getInstance = async (channel, user, force, pretty, full, error) => {
-    force = force?.toLowerCase() === 'true';
-    full = full?.toLowerCase() === 'true';
-    const instances = data.justlogsInstances;
+    userChanRegex = /^[a-z0-9]\w{0,24}$|^id:(\d{1,})$/i;
 
-    let downSites = 0;
-    let userLinks = [];
-    let channelLinks = [];
-    let userInstances = [];
-    let channelInstances = [];
-
-    if (Number(await utils.redis.get(`logs:updated`)) - Math.round(new Date().getTime() / 1000) > 86400) force = true;
-
-    const start = performance.now();
-    if (!error)
-        for (const Website of instances) {
-            const { Status, Link, Full, channelFull } = await utils.getLogs(Website, user, channel, force, pretty);
-            switch (Status) {
-                case 0:
-                    downSites++;
-                    continue;
-                case 1:
-                    channelLinks.push(channelFull);
-                    channelInstances.push(Link);
-                    userInstances.push(Link);
-                    userLinks.push(Full);
-                    if (full) {
-                        continue;
-                    }
-                    break;
-                case 2:
-                    channelLinks.push(channelFull);
-                    channelInstances.push(Link);
-                    continue;
-                case 3:
-                    continue;
-            }
-            break;
-        }
-
-    if (force) await utils.redis.set(`logs:updated`, Math.round(new Date().getTime() / 1000));
-
-    if (!error && !channelInstances.length) error = 'No channel logs found';
-    else if (!error && !userInstances.length && user) error = 'No user logs found';
-    const end = performance.now();
-
-    return {
-        error: error,
-        instancesInfo: {
-            count: instances.length,
-            down: downSites,
-        },
-        request: {
-            user: user,
-            channel: channel,
-            forced: force,
-            full: full,
-        },
-        available: {
-            user: userInstances.length > 0 ? true : false,
-            channel: channelInstances.length > 0 ? true : false,
-        },
-        userLogs: {
-            count: userInstances.length,
-            instances: userInstances,
-            fullLink: userLinks,
-        },
-        channelLogs: {
-            count: channelInstances.length,
-            instances: channelInstances,
-            fullLink: channelLinks,
-        },
-        lastUpdated: {
-            unix: Number(await utils.redis.get(`logs:updated`)),
-            utc: new Date((await utils.redis.get(`logs:updated`)) * 1000).toUTCString(),
-        },
-        elapsed: {
-            ms: Math.round((end - start) * 100) / 100,
-            s: Math.round((end - start) / 10) / 100,
-        },
-    };
-};
-
-exports.getLogs = async (url, user, channel, force, pretty) => {
-    let logsInfo = {
-        Status: Number,
-        Link: String ?? null,
-        Full: String ?? null,
-        channelFull: String ?? null,
-    };
-
-    let Channels;
-    const cacheData = await utils.redis.get(`logs:instance:${url}`);
-
-    if (cacheData && !force) {
-        Channels = JSON.parse(cacheData);
-    } else {
-        try {
-            var logsData = await got(`https://${url}/channels`, {
-                headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
-                responseType: 'json',
-                timeout: 5000,
-                http2: true,
-            });
-            Channels = [].concat(
-                logsData.body.channels.map((i) => i.name),
-                logsData.body.channels.map((i) => i.userID),
-            );
-            await utils.redis.set(`logs:instance:${url}`, JSON.stringify(Channels));
-        } catch (err) {
-            logsInfo.Status = 0;
-            return logsInfo;
-        }
+    formatUsername(username) {
+        return decodeURIComponent(username.replace(/[@#,]/g, '').toLowerCase());
     }
 
-    const channelPath = channel.match(/^id:(\d{1,})$/i) ? 'channelid' : 'channel';
-    const channelClean = channel.replace('id:', '');
+    async getInstance(channel, user, force, pretty, full, error) {
+        force = force?.toLowerCase() === 'true';
+        full = full?.toLowerCase() === 'true';
+        const instances = data.justlogsInstances;
+    
+        let downSites = 0;
+        let userLinks = [];
+        let channelLinks = [];
+        let userInstances = [];
+        let channelInstances = [];
+    
+        if (Number(await this.redis.get(`logs:updated`)) - Math.round(new Date().getTime() / 1000) > 86400) force = true;
+    
+        const start = performance.now();
+        if (!error)
+            await Promise.allSettled(instances.map(async (Website) => {
+                const { Status, Link, Full, channelFull } = await this.getLogs(Website, user, channel, force, pretty);
+                switch (Status) {
+                    case 0:
+                        downSites++;
+                        return;
+                    case 1:
+                        channelLinks.push(channelFull);
+                        channelInstances.push(Link);
+                        userInstances.push(Link);
+                        userLinks.push(Full);
+                        if (full) {
+                            return;
+                        }
+                        break;
+                    case 2:
+                        channelLinks.push(channelFull);
+                        channelInstances.push(Link);
+                        return;
+                    case 3:
+                        return;
+                }
+            })).then(res => res.filter(r => r.status === 'fulfilled')).map(r => r.value);
+    
+        if (force) await this.redis.set(`logs:updated`, Math.round(new Date().getTime() / 1000));
+    
+        if (!error && !channelInstances.length) error = 'No channel logs found';
+        else if (!error && !userInstances.length && user) error = 'No user logs found';
+        const end = performance.now();
+    
+        return {
+            error: error,
+            instancesInfo: {
+                count: instances.length,
+                down: downSites,
+            },
+            request: {
+                user: user,
+                channel: channel,
+                forced: force,
+                full: full,
+            },
+            available: {
+                user: userInstances.length > 0 ? true : false,
+                channel: channelInstances.length > 0 ? true : false,
+            },
+            userLogs: {
+                count: userInstances.length,
+                instances: userInstances,
+                fullLink: userLinks,
+            },
+            channelLogs: {
+                count: channelInstances.length,
+                instances: channelInstances,
+                fullLink: channelLinks,
+            },
+            lastUpdated: {
+                unix: Number(await this.redis.get(`logs:updated`)),
+                utc: new Date((await this.redis.get(`logs:updated`)) * 1000).toUTCString(),
+            },
+            elapsed: {
+                ms: Math.round((end - start) * 100) / 100,
+                s: Math.round((end - start) / 10) / 100,
+            },
+        };
+    };
 
-    if (!user && Channels.includes(channelClean)) {
-        logsInfo.Status = 2;
-        logsInfo.Link = `https://${url}`;
-        logsInfo.channelFull =
-            pretty?.toLowerCase() === 'false'
-                ? `https://${url}/?channel=${channel}`
-                : `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
-        return logsInfo;
-    } else if (Channels.includes(channelClean)) {
-        const cacheData = await utils.redis.get(
-            `logs:instance:${url}:${channel.replace('id:', 'id-')}:${user.replace('id:', 'id-')}`,
-        );
-        let Code;
-
-        const userPath = user.match(/^id:(\d{1,})$/i) ? 'userid' : 'user';
-        const userClean = user.replace('id:', '');
-
+    async getLogs(url, user, channel, force, pretty) {
+        let logsInfo = {
+            Status: Number,
+            Link: String ?? null,
+            Full: String ?? null,
+            channelFull: String ?? null,
+        };
+    
+        let Channels;
+        const cacheData = await this.redis.get(`logs:instance:${url}`);
+    
         if (cacheData && !force) {
-            Code = JSON.parse(cacheData);
+            Channels = JSON.parse(cacheData);
         } else {
-            const { statusCode } = await got(`https://${url}/${channelPath}/${channelClean}/${userPath}/${userClean}`, {
-                headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
-                throwHttpErrors: false,
-                timeout: 5000,
-                http2: true,
-            });
-            await utils.redis.set(
-                `logs:instance:${url}:${channel.replace('id:', 'id-')}:${user.replace('id:', 'id-')}`,
-                statusCode,
-                'EX',
-                86400,
-            );
-            Code = statusCode;
+            try {
+                const logsData = await got(`https://${url}/channels`, {
+                    headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
+                    responseType: 'json',
+                    timeout: 5000,
+                    http2: true,
+                });
+                Channels = [].concat(
+                    logsData.body.channels.map((i) => i.name),
+                    logsData.body.channels.map((i) => i.userID),
+                );
+                await this.redis.set(`logs:instance:${url}`, JSON.stringify(Channels));
+            } catch (err) {
+                logsInfo.Status = 0;
+                return logsInfo;
+            }
         }
-
-        if (Code < 200 || Code > 299) {
+    
+        const channelPath = channel.match(this.userIdRegex) ? 'channelid' : 'channel';
+        const channelClean = channel.replace('id:', '');
+    
+        if (!user && Channels.includes(channelClean)) {
             logsInfo.Status = 2;
             logsInfo.Link = `https://${url}`;
             logsInfo.channelFull =
                 pretty?.toLowerCase() === 'false'
                     ? `https://${url}/?channel=${channel}`
                     : `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
-        } else {
-            logsInfo.Status = 1;
-            logsInfo.Link = `https://${url}`;
-            logsInfo.Full =
-                pretty?.toLowerCase() === 'true'
-                    ? `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}/${userPath}/${userClean}`
-                    : `https://${url}/?channel=${channel}&username=${user}`;
-            logsInfo.channelFull =
-                pretty?.toLowerCase() === 'false'
-                    ? `https://${url}/?channel=${channel}`
-                    : `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
+            return logsInfo;
+        } else if (Channels.includes(channelClean)) {
+            const cacheData = await this.redis.get(
+                `logs:instance:${url}:${channel.replace('id:', 'id-')}:${user.replace('id:', 'id-')}`,
+            );
+            let Code;
+    
+            const userPath = user.match(this.userIdRegex) ? 'userid' : 'user';
+            const userClean = user.replace('id:', '');
+    
+            if (cacheData && !force) {
+                Code = JSON.parse(cacheData);
+            } else {
+                const { statusCode } = await got(`https://${url}/${channelPath}/${channelClean}/${userPath}/${userClean}`, {
+                    headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
+                    throwHttpErrors: false,
+                    timeout: 5000,
+                    http2: true,
+                });
+                await this.redis.set(
+                    `logs:instance:${url}:${channel.replace('id:', 'id-')}:${user.replace('id:', 'id-')}`,
+                    statusCode,
+                    'EX',
+                    86400,
+                );
+                Code = statusCode;
+            }
+    
+            if (Code < 200 || Code > 299) {
+                logsInfo.Status = 2;
+                logsInfo.Link = `https://${url}`;
+                logsInfo.channelFull =
+                    pretty?.toLowerCase() === 'false'
+                        ? `https://${url}/?channel=${channel}`
+                        : `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
+            } else {
+                logsInfo.Status = 1;
+                logsInfo.Link = `https://${url}`;
+                logsInfo.Full =
+                    pretty?.toLowerCase() === 'true'
+                        ? `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}/${userPath}/${userClean}`
+                        : `https://${url}/?channel=${channel}&username=${user}`;
+                logsInfo.channelFull =
+                    pretty?.toLowerCase() === 'false'
+                        ? `https://${url}/?channel=${channel}`
+                        : `https://logs.raccatta.cc/${url}/${channelPath}/${channelClean}`;
+            }
+    
+            return logsInfo;
         }
-
+    
+        logsInfo.Status = 3;
         return logsInfo;
-    }
+    };
 
-    logsInfo.Status = 3;
-    return logsInfo;
-};
-
-exports.getRecentMessages = async (channel, searchParams) => {
-    const instances = data.recentmessagesInstances;
-
-    let finalInstance = null;
-    let statusMessage = null;
-    let messagesData = [];
-    let errorCode = null;
-    let status = null;
-    let error = null;
-    let end = null;
-
-    const start = performance.now();
-
-    const fetchMessages = async (instance) => {
-        const { body, statusCode } = await got(`https://${instance}/api/v2/recent-messages/${channel}`, {
+    async fetchMessages(instance, channel, searchParams) {
+        return got(`https://${instance}/api/v2/recent-messages/${channel}`, {
             headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
             throwHttpErrors: false,
             responseType: 'json',
             timeout: 5000,
             searchParams,
         });
-
-        return { body, statusCode };
     };
+    
+    async getRecentMessages(channel, searchParams) {  
+        const 
+        instances = data.recentmessagesInstances,
 
-    for (const instance of instances) {
-        const { body, statusCode } = await fetchMessages(instance);
+        start = performance.now(),
 
-        if (statusCode === 200 && body.messages.length) {
-            finalInstance = `https://${instance}`;
-            messagesData = body.messages;
-            break;
+        results = await Promise.allSettled(instances.map(async (instance) => {
+            const { body, statusCode } = await fetchMessages(instance, channel, searchParams);
+
+            if (statusCode === 200 && body.messages.length) {
+                return {
+                    foundInstance: `https://${instance}`,
+                    messagesData: body.messages
+                }
+            } 
+            return {
+                statusMessage: body?.status_message ?? 'Internal Server Error',
+                errorCode: body?.error_code ?? 'internal_server_error',
+                error: body?.error ?? 'Internal Server Error',
+                status: statusCode ?? '500'
+            }
+        })).filter(res => res.status === 'fulfilled'),
+
+        end = performance.now(),
+
+        elapsed = {
+            ms: Math.round((end - start) * 100) / 100,
+            s: Math.round((end - start) / 10) / 100,
+        },
+
+        instance = results.find(res => res.value?.foundInstance);
+        if (instance) {
+            const { foundInstance, messagesData } = instance.value;
+            return { messages: messagesData, error: null, error_code: null, instance: foundInstance, elapsed }
         } else {
-            statusMessage = body?.status_message || 'Internal Server Error';
-            errorCode = body?.error_code || 'internal_server_error';
-            error = body?.error || 'Internal Server Error';
-            status = statusCode || '500';
+            const { statusMessage, errorCode, status, error } = results[0].value;
+            return { messages: [], status, status_message: statusMessage, error, error_code: errorCode, elapsed };
         }
-    }
-
-    end = performance.now();
-    const elapsed = {
-        ms: Math.round((end - start) * 100) / 100,
-        s: Math.round((end - start) / 10) / 100,
     };
 
-    const response = finalInstance
-        ? { messages: messagesData, error: null, error_code: null, instance: finalInstance, elapsed }
-        : { messages: [], status, status_message: statusMessage, error, error_code: errorCode, elapsed };
-
-    return response;
-};
-
-exports.getInfo = async (user) => {
-    const { body, statusCode } = await got(`https://api.ivr.fi/v2/twitch/user?login=${user}`, {
-        headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
-        throwHttpErrors: false,
-        responseType: 'json',
-        timeout: 5000,
-    });
-    if (statusCode < 200 || statusCode > 299) return null;
-
-    const displayName = body[0].displayName.toLowerCase() === user ? body[0].displayName : user;
-    return { name: displayName, avatar: body[0].logo, id: body[0].id };
-};
+    async getInfo(user) {
+        const { body, statusCode } = await got(`https://api.ivr.fi/v2/twitch/user?login=${user}`, {
+            headers: { 'User-Agent': 'Best Logs by ZonianMidian' },
+            throwHttpErrors: false,
+            responseType: 'json',
+            timeout: 5000,
+        });
+        if (statusCode < 200 || statusCode > 299) return null;
+    
+        const displayName = body[0].displayName.toLowerCase() === user ? body[0].displayName : user;
+        return { name: displayName, avatar: body[0].logo, id: body[0].id };
+    };
+}

--- a/utils.js
+++ b/utils.js
@@ -127,7 +127,6 @@ module.exports = new class LogUtils {
                 user: user,
                 channel: channel,
                 forced: force,
-                full: full,
             },
             available: {
                 user: userInstances.length > 0 ? true : false,


### PR DESCRIPTION
Use the Promise.allSettled method to load all logs/rm instances concurrently instead of sequentially.

Minor refactor to load utils functions into memory as a singleton instance instead of exports.