### PR TITLE
Skip known-down instances when fetching logs and name history

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -224,7 +224,10 @@ export class Utils {
 		}
 
 		if (!error) {
-			const results = await Promise.allSettled(instances.map((i) => this.getLogs(i, user, channel, force, pretty, banned)));
+			const aliveInstances = instances.filter(
+				(url) => !(Array.isArray(this.instanceChannels.get(url)) && this.instanceChannels.get(url).length === 0),
+			);
+			const results = await Promise.allSettled(aliveInstances.map((i) => this.getLogs(i, user, channel, force, pretty, banned)));
 			const resolvedInstances = results.filter(({ status }) => status === 'fulfilled').map(({ value }) => value);
 
 			for (const instance of resolvedInstances) {
@@ -640,8 +643,12 @@ export class Utils {
 
 		let nameHistory = [];
 
+		const nameHistoryInstances = Object.keys(this.config.justlogsInstances).filter(
+			(url) => !(Array.isArray(this.instanceChannels.get(url)) && this.instanceChannels.get(url).length === 0),
+		);
+
 		await Promise.allSettled(
-			Object.keys(this.config.justlogsInstances).map(async (url) => {
+			nameHistoryInstances.map(async (url) => {
 				try {
 					const instanceURL = this.config.justlogsInstances[url]?.alternate ?? url;
 					const historyData = await this.request(`https://${instanceURL}/namehistory/${user}`, {


### PR DESCRIPTION
When getInstance() and getNameHistory() fire concurrent requests to all configured Rustlog instances, they currently wait for every instance to respond  — including ones already known to be down (confirmed by the periodic health check in loadInstanceChannels()). This could add unnecessary latency equal to the timeout duration (5-10s) for each dead instance in the worst case.

Example:
If 3 out of 20 instances are down, the old code waits up to 10s for each before the Promise.allSettled resolves — adding up to 30s of unnecessary delay in the worst case. After this change, those instances are skipped immediately via the existing instanceChannels map (empty array = down), so the response comes back as soon as the remaining 17 instances respond. Unknown instances (no health-check entry yet) are still tried.


and maybe even more beneficial with 9 out of 22 being unresponsive/offline currently
